### PR TITLE
fix: auto-release gh token

### DIFF
--- a/.github/workflows/auto-release-pr.yml
+++ b/.github/workflows/auto-release-pr.yml
@@ -95,6 +95,8 @@ jobs:
         if: steps.create.outputs.pr_merged == 'true'
         id: release
         shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT || github.token }}
         run: |
           set -euo pipefail
           PR_NUMBER="${{ steps.create.outputs.pr_number }}"
@@ -110,7 +112,6 @@ jobs:
 
           owner=$(cut -d/ -f1 <<< "${GITHUB_REPOSITORY}")
           repo=$(cut -d/ -f2 <<< "${GITHUB_REPOSITORY}")
-          export GH_TOKEN="${GITHUB_TOKEN}"
 
           mapfile -t PR_FILES < <(gh api "repos/${owner}/${repo}/pulls/${PR_NUMBER}/files" --paginate \
             --jq '.[] | [.status, .filename, (.previous_filename // "")] | @tsv')
@@ -121,6 +122,7 @@ jobs:
             exit 1
           fi
 
+          # Replay only the files touched by the PR
           for entry in "${PR_FILES[@]}"; do
             IFS=$'\t' read -r status filename previous <<<"$entry"
             case "$status" in


### PR DESCRIPTION
Corrige el uso de gh CLI dentro del job de release usando env.GH_TOKEN y vuelve a gatillar la prueba de overrides.