### PR TITLE
fix: avoid key.pem self-copy during prod deploy

### DIFF
--- a/.github/workflows/ci-cd-pipeline.yml
+++ b/.github/workflows/ci-cd-pipeline.yml
@@ -929,7 +929,12 @@ jobs:
             ln -sf ../config.lua current/config.lua
             # IMPORTANT: Always ensure key.pem is in current/ (required by server)
             if [ -f key.pem ]; then
-              cp -f key.pem current/key.pem
+              mkdir -p current
+              src_real=$(readlink -f key.pem 2>/dev/null || echo "")
+              dest_real=$(readlink -f current/key.pem 2>/dev/null || echo "")
+              if [ "$src_real" != "$dest_real" ]; then
+                cp -f key.pem current/key.pem
+              fi
               chmod 640 current/key.pem
               # Also create symlink from root to current/ for compatibility
               ln -sf current/key.pem key.pem


### PR DESCRIPTION
Hotfix for production: skip the cp when key.pem already points to current/key.pem to prevent drone-ssh failure.