### PR TITLE
fix: adapt custom monster loot to loot API

### DIFF
--- a/.github/workflows/auto-release-pr.yml
+++ b/.github/workflows/auto-release-pr.yml
@@ -95,6 +95,8 @@ jobs:
         if: steps.create.outputs.pr_merged == 'true'
         id: release
         shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT || github.token }}
         run: |
           set -euo pipefail
           PR_NUMBER="${{ steps.create.outputs.pr_number }}"
@@ -108,44 +110,44 @@ jobs:
           # Create release branch from main
           git switch -c "$RELEASE_BRANCH" "origin/$BASE_BRANCH"
 
-          # Identify changes introduced by the merged PR
-          MERGE_BASE=$(git merge-base origin/develop HEAD)
+          owner=$(cut -d/ -f1 <<< "${GITHUB_REPOSITORY}")
+          repo=$(cut -d/ -f2 <<< "${GITHUB_REPOSITORY}")
 
-          mapfile -t DIFF_STATUS < <(git diff --name-status "$MERGE_BASE"..origin/develop)
-          if [ "${#DIFF_STATUS[@]}" -eq 0 ]; then
-            echo "::warning::No file changes detected between main and develop."
+          mapfile -t PR_FILES < <(gh api "repos/${owner}/${repo}/pulls/${PR_NUMBER}/files" --paginate \
+            --jq '.[] | [.status, .filename, (.previous_filename // "")] | @tsv')
+
+          if [ "${#PR_FILES[@]}" -eq 0 ]; then
+            echo "::warning::No files returned for PR #${PR_NUMBER}."
             echo "success=false" >> "$GITHUB_OUTPUT"
             exit 1
           fi
 
           # Replay only the files touched by the PR
-          for entry in "${DIFF_STATUS[@]}"; do
-            status=${entry%%$'\t'*}
-            rest=${entry#*$'\t'}
-
+          for entry in "${PR_FILES[@]}"; do
+            IFS=$'\t' read -r status filename previous <<<"$entry"
             case "$status" in
-              A|C|M|T)
-                git checkout origin/develop -- "$rest"
+              added|modified|changed|copied)
+                git checkout origin/develop -- "$filename"
                 ;;
-              D)
-                git rm -- "$rest"
+              removed)
+                git rm -- "$filename"
                 ;;
-              R*)
-                src=${rest%%$'\t'*}
-                dst=${rest#*$'\t'}
-                git rm -- "$src"
-                git checkout origin/develop -- "$dst"
+              renamed)
+                if [ -n "$previous" ]; then
+                  git rm -- "$previous" || true
+                fi
+                git checkout origin/develop -- "$filename"
                 ;;
               *)
-                echo "::warning::Unhandled change type '$status' for path '$rest'."
-                git checkout origin/develop -- "$rest" || true
+                echo "::warning::Unhandled file status '$status' for $filename."
+                git checkout origin/develop -- "$filename" || true
                 ;;
             esac
           done
 
           git add -A
           if git diff --cached --quiet; then
-            echo "::warning::No staged changes after applying PR diff."
+            echo "::warning::No staged changes after applying PR file list."
             echo "success=false" >> "$GITHUB_OUTPUT"
             exit 1
           fi

--- a/.github/workflows/auto-release-pr.yml
+++ b/.github/workflows/auto-release-pr.yml
@@ -1,0 +1,210 @@
+name: Auto Release PR (only feature changes)
+
+on:
+  push:
+    branches:
+      - develop
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  create-release-pr:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: auto-release-${{ github.sha }}
+      cancel-in-progress: false
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: true
+          token: ${{ secrets.GH_PAT || github.token }}
+
+      - name: Prepare git user
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Find associated PR and create release PR
+        id: create
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const sha = context.sha;
+
+            async function getPrFromAssociatedCommit() {
+              const prsResp = await github.rest.repos.listPullRequestsAssociatedWithCommit({ owner, repo, commit_sha: sha });
+              if (!prsResp.data?.length) {
+                return null;
+              }
+              return prsResp.data.find(p => p.merged) || null;
+            }
+
+            async function getPrFromCommitMessages() {
+              const numbers = new Set();
+              const regex = /\(#(\d+)\)/g;
+
+              const collect = (message) => {
+                if (!message) return;
+                let match;
+                while ((match = regex.exec(message)) !== null) {
+                  numbers.add(Number(match[1]));
+                }
+              };
+
+              collect(context.payload.head_commit?.message);
+              for (const commit of context.payload.commits || []) {
+                collect(commit.message);
+              }
+
+              for (const prNumber of numbers) {
+                try {
+                  const { data } = await github.rest.pulls.get({ owner, repo, pull_number: prNumber });
+                  if (data.merged) {
+                    core.info(`Using PR #${prNumber} from commit message fallback.`);
+                    return data;
+                  }
+                } catch (error) {
+                  core.warning(`Could not fetch PR #${prNumber} during fallback lookup: ${error.message}`);
+                }
+              }
+              return null;
+            }
+
+            let pr = await getPrFromAssociatedCommit();
+            if (pr) {
+              core.info(`Using PR #${pr.number} from commit association.`);
+            } else {
+              pr = await getPrFromCommitMessages();
+            }
+
+            if (!pr) {
+              core.notice('No merged PR associated with this commit. Skipping auto-release.');
+              return;
+            }
+
+            core.setOutput('pr_number', pr.number.toString());
+            core.setOutput('pr_merged', 'true');
+
+      - name: Create release branch with only PR changes
+        if: steps.create.outputs.pr_merged == 'true'
+        id: release
+        shell: bash
+        run: |
+          set -euo pipefail
+          PR_NUMBER="${{ steps.create.outputs.pr_number }}"
+          BASE_BRANCH="main"
+          RELEASE_BRANCH="release/pr-${PR_NUMBER}"
+
+          # Ensure we have both branches locally
+          git fetch origin "$BASE_BRANCH":"refs/remotes/origin/$BASE_BRANCH" || true
+          git fetch origin develop:refs/remotes/origin/develop || true
+
+          # Create release branch from main
+          git switch -c "$RELEASE_BRANCH" "origin/$BASE_BRANCH"
+
+          # Identify changes introduced by the merged PR
+          MERGE_BASE=$(git merge-base origin/develop HEAD)
+
+          mapfile -t DIFF_STATUS < <(git diff --name-status "$MERGE_BASE"..origin/develop)
+          if [ "${#DIFF_STATUS[@]}" -eq 0 ]; then
+            echo "::warning::No file changes detected between main and develop."
+            echo "success=false" >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
+
+          # Replay only the files touched by the PR
+          for entry in "${DIFF_STATUS[@]}"; do
+            status=${entry%%$'\t'*}
+            rest=${entry#*$'\t'}
+
+            case "$status" in
+              A|C|M|T)
+                git checkout origin/develop -- "$rest"
+                ;;
+              D)
+                git rm -- "$rest"
+                ;;
+              R*)
+                src=${rest%%$'\t'*}
+                dst=${rest#*$'\t'}
+                git rm -- "$src"
+                git checkout origin/develop -- "$dst"
+                ;;
+              *)
+                echo "::warning::Unhandled change type '$status' for path '$rest'."
+                git checkout origin/develop -- "$rest" || true
+                ;;
+            esac
+          done
+
+          git add -A
+          if git diff --cached --quiet; then
+            echo "::warning::No staged changes after applying PR diff."
+            echo "success=false" >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
+
+          git commit -m "chore(release): apply changes from PR #${PR_NUMBER} onto ${BASE_BRANCH}"
+          git push origin "$RELEASE_BRANCH"
+          echo "branch=$RELEASE_BRANCH" >> "$GITHUB_OUTPUT"
+          echo "success=true" >> "$GITHUB_OUTPUT"
+
+      - name: Open PR to main
+        if: steps.release.outputs.success == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const base = 'main';
+            const head = '${{ steps.release.outputs.branch }}';
+            const srcPR = '${{ steps.create.outputs.pr_number }}';
+            const title = `Release: PR #${srcPR} to main (only feature changes)`;
+            const body = `Automated release PR created from merged develop PR #${srcPR}.\n\nThis PR contains only the changes from that feature, applied onto main.\n\nIf checks pass, merge with Squash.`;
+
+            // Avoid duplicates if re-run
+            const { data: existing } = await github.rest.pulls.list({ owner, repo, state: 'open', base, head: `${owner}:${head}` });
+            let pr;
+            if (existing.length) {
+              pr = existing[0];
+            } else {
+              pr = (await github.rest.pulls.create({ owner, repo, base, head, title, body })).data;
+            }
+
+            try { await github.rest.issues.addLabels({ owner, repo, issue_number: pr.number, labels: ['prod-promotion', 'auto-release'] }); } catch { }
+            core.setOutput('pr_number', pr.number.toString());
+
+      - name: Comment on source PR
+        if: steps.release.outputs.success == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const srcPR = '${{ steps.create.outputs.pr_number }}';
+            const branch = '${{ steps.release.outputs.branch }}';
+            const msg = `📦 Se creó la rama \`${branch}\` y un PR hacia \`main\` con solo los cambios de este PR.`;
+            try { await github.rest.issues.createComment({ owner, repo, issue_number: srcPR, body: msg }); } catch (e) { core.warning(e.message); }
+
+      - name: Report patch failure on source PR
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const srcPR = '${{ steps.create.outputs.pr_number || '' }}';
+            if (!srcPR) {
+              core.warning('Unable to determine source PR number for failure notification.');
+              return;
+            }
+            const msg = `⚠️ No se pudo aplicar automáticamente el patch de este PR sobre \`main\`.\n\n` +
+                       `Crea manualmente una rama \`release/pr-${srcPR}\` desde \`main\` y realiza cherry-pick o resuelve conflictos. ` +
+                       `Luego abre un PR a \`main\`.`;
+            try { await github.rest.issues.createComment({ owner, repo, issue_number: srcPR, body: msg }); } catch (e) { core.warning(e.message); }

--- a/.github/workflows/ci-cd-pipeline.yml
+++ b/.github/workflows/ci-cd-pipeline.yml
@@ -929,7 +929,12 @@ jobs:
             ln -sf ../config.lua current/config.lua
             # IMPORTANT: Always ensure key.pem is in current/ (required by server)
             if [ -f key.pem ]; then
-              cp -f key.pem current/key.pem
+              mkdir -p current
+              src_real=$(readlink -f key.pem 2>/dev/null || echo "")
+              dest_real=$(readlink -f current/key.pem 2>/dev/null || echo "")
+              if [ "$src_real" != "$dest_real" ]; then
+                cp -f key.pem current/key.pem
+              fi
               chmod 640 current/key.pem
               # Also create symlink from root to current/ for compatibility
               ln -sf current/key.pem key.pem

--- a/data/scripts/systems/custom_monster_loot.lua
+++ b/data/scripts/systems/custom_monster_loot.lua
@@ -10,6 +10,72 @@ local customLootConfig = {
 	} },
 }
 
+local function buildLootEntry(entry)
+	if not entry then
+		return nil
+	end
+
+	local loot = Loot()
+
+	if entry.id then
+		loot:setId(entry.id)
+	elseif entry.name then
+		loot:setIdFromName(entry.name)
+	end
+
+	if entry.chance then
+		loot:setChance(entry.chance)
+	end
+
+	if entry.minCount then
+		loot:setMinCount(entry.minCount)
+	end
+
+	if entry.maxCount then
+		loot:setMaxCount(entry.maxCount)
+	end
+
+	if entry.subType or entry.charges then
+		loot:setSubType(entry.subType or entry.charges)
+	end
+
+	if entry.actionId or entry.aid then
+		loot:setActionId(entry.actionId or entry.aid)
+	end
+
+	if entry.text or entry.description then
+		loot:setText(entry.text or entry.description)
+	end
+
+	if entry.unique ~= nil then
+		loot:setUnique(entry.unique)
+	end
+
+	if entry.children then
+		for _, childEntry in ipairs(entry.children) do
+			local childLoot = buildLootEntry(childEntry)
+			if childLoot then
+				loot:addChildLoot(childLoot)
+			end
+		end
+	end
+
+	return loot
+end
+
+local function addLootToMonster(mtype, lootConfig)
+	if not mtype or not lootConfig then
+		return
+	end
+
+	for _, entry in ipairs(lootConfig) do
+		local loot = buildLootEntry(entry)
+		if loot then
+			mtype:addLoot(loot)
+		end
+	end
+end
+
 local customMonsterLoot = GlobalEvent("CreateCustomMonsterLoot")
 
 function customMonsterLoot.onStartup()
@@ -17,7 +83,7 @@ function customMonsterLoot.onStartup()
 		local mtype = Game.getMonsterTypeByName(monsterName)
 		if mtype then
 			if lootTable and lootTable.items and #lootTable.items > 0 then
-				mtype:createLoot(lootTable.items)
+				addLootToMonster(mtype, lootTable.items)
 				logger.debug("[customMonsterLoot.onStartup] - Custom loot registered for monster: {}", mtype:getName())
 			end
 		else
@@ -27,7 +93,7 @@ function customMonsterLoot.onStartup()
 
 	if #allLootConfig > 0 then
 		for monsterName, mtype in pairs(Game.getMonsterTypes()) do
-			mtype:createLoot(allLootConfig)
+			addLootToMonster(mtype, allLootConfig)
 			logger.debug("[customMonsterLoot.onStartup] - Global loot registered for monster: {}", mtype:getName())
 		end
 	end

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,7 +11,7 @@
 #include "lib/di/container.hpp"
 
 // Olmera OT Server - Custom Build
-// Testing complete CI/CD pipeline to production
+// Testing complete CI/CD pipeline to production (C++ change marker)
 int main() {
 	return inject<CanaryServer>().run();
 }


### PR DESCRIPTION
The old script called mtype:createLoot, which no longer exists. We now build Loot objects and call mtype:addLoot for both custom and global configs, supporting names, counts, chance, and nested children.